### PR TITLE
Move dependency on genmesh to feature 'usegenmesh'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: rust
 script:
     - cargo build
     - cargo test
+    - cargo test --features "usegenmesh"
     - cargo doc
 
 after_script:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "obj"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Colin Sherratt <colin.sherratt@gmail.com>",
 ]
@@ -20,5 +20,9 @@ exclude = [
 name = "obj"
 path = "src/lib.rs"
 
+[features]
+default = []
+usegenmesh = ["genmesh"]
+
 [dependencies]
-genmesh = "0.3.*"
+genmesh = { version = "0.3.*", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@
 #![crate_name = "obj"]
 #![crate_type = "lib"]
 
+#[cfg(feature = "usegenmesh")]
 extern crate genmesh;
 
 use std::fs::File;
@@ -25,13 +26,13 @@ use std::rc::Rc;
 use std::iter::Filter;
 use std::str::Split;
 
-pub use obj::{Obj, Object, Group, IndexTuple};
+pub use obj::{Obj, Object, Group, IndexTuple, GenPolygon, SimplePolygon};
 pub use mtl::{Mtl, Material};
 
 mod obj;
 mod mtl;
 
-pub fn load(path: &Path) -> io::Result<Obj<Rc<Material>>> {
+pub fn load<P: GenPolygon>(path: &Path) -> io::Result<Obj<Rc<Material>,P>> {
     File::open(path).map(|f| {
         let mut f = BufReader::new(f);
         let obj = Obj::load(&mut f);

--- a/tests/cube.rs
+++ b/tests/cube.rs
@@ -12,11 +12,15 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
+#[cfg(feature = "usegenmesh")]
 extern crate genmesh;
 extern crate obj;
 
 use std::io::BufReader;
-use obj::Obj;
+use obj::{Obj, SimplePolygon};
+#[cfg(feature = "usegenmesh")]
+use obj::IndexTuple;
+#[cfg(feature = "usegenmesh")]
 use genmesh::{MapToVertices, Polygon};
 
 static SQUARE: &'static str = "
@@ -35,9 +39,10 @@ static SQUARE_VBO: &'static [[f32; 3]] = &[
 ];
 
 #[test]
+#[cfg(feature = "usegenmesh")]
 fn test_load_square() {
     let mut reader = BufReader::new(SQUARE.as_bytes());
-    let obj = Obj::load(&mut reader);
+    let obj = Obj::<Polygon<IndexTuple>>::load(&mut reader);
 
     let v = obj.position();
 
@@ -61,6 +66,18 @@ fn test_load_square() {
         }
     }
 
+}
+
+#[test]
+fn test_load_square_nodeps() {
+    let mut reader = BufReader::new(SQUARE.as_bytes());
+    let obj = Obj::<SimplePolygon>::load(&mut reader);
+
+    let v = obj.position();
+
+    for (a, b) in v.iter().zip(SQUARE_VBO.iter()) {
+        assert_eq!(a, b);
+    }
 }
 
 static CUBE: &'static str = "
@@ -112,9 +129,29 @@ static CUBE_NAMES: &'static [&'static str] = &[
 
 
 #[test]
+#[cfg(feature = "usegenmesh")]
 fn test_load_cube() {
     let mut reader = BufReader::new(CUBE.as_bytes());
-    let obj = Obj::load(&mut reader);
+    let obj = Obj::<Polygon<IndexTuple>>::load(&mut reader);
+
+    let v = obj.position();
+
+    for (a, b) in v.iter().zip(CUBE_VBO.iter()) {
+        assert_eq!(a, b);
+    }
+
+    for obj in obj.object_iter() {
+        assert_eq!(obj.name, "cube");
+        for (g, &name) in obj.group_iter().zip(CUBE_NAMES.iter()) {
+            assert_eq!(name, g.name);
+        }
+    }
+}
+
+#[test]
+fn test_load_cube_nodeps() {
+    let mut reader = BufReader::new(CUBE.as_bytes());
+    let obj = Obj::<SimplePolygon>::load(&mut reader);
 
     let v = obj.position();
 
@@ -196,9 +233,22 @@ f -4 -3 -2 -1
 ";
 
 #[test]
+#[cfg(feature = "usegenmesh")]
 fn test_load_cube_negative() {
     let mut reader = BufReader::new(CUBE_NEGATIVE.as_bytes());
-    let obj = Obj::load(&mut reader);
+    let obj = Obj::<Polygon<IndexTuple>>::load(&mut reader);
+
+    let v = obj.position();
+
+    for (a, b) in v.iter().zip(CUBE_NEGATIVE_VBO.iter()) {
+        assert_eq!(a, b);
+    }
+}
+
+#[test]
+fn test_load_cube_negative_nodeps() {
+    let mut reader = BufReader::new(CUBE_NEGATIVE.as_bytes());
+    let obj = Obj::<SimplePolygon>::load(&mut reader);
 
     let v = obj.position();
 

--- a/tests/load_obj_file.rs
+++ b/tests/load_obj_file.rs
@@ -12,12 +12,12 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 
-extern crate genmesh;
 extern crate obj;
 
 use std::path::Path;
+use obj::{SimplePolygon};
 
 #[test]
 fn load_test_file() {
-    let _ = obj::load(&Path::new("test_assets/sponza.obj"));
+    let _ = obj::load::<SimplePolygon>(&Path::new("test_assets/sponza.obj"));
 }


### PR DESCRIPTION
Dependency on genmesh creates rather lengthy list of sub-dependencies. Namely: libc, winapi-build, rustc-serialize, winapi, advapi32-sys, rand, num, cgmath